### PR TITLE
CF fixes

### DIFF
--- a/lib/roart/core/hash.rb
+++ b/lib/roart/core/hash.rb
@@ -1,15 +1,23 @@
 class Hash
-  def to_content_format
-    fields = self.map do |key,value|
-      unless value.nil?
-        value = Roart::ContentFormatter.format_string(value.to_s)
+   def to_content_format
+    fields = []
+
+    self.each do |key, values|
+      next if values.nil?
+
+      key_name = 
         if key.to_s.match(/^cf_.+/)
-          "CF-#{key.to_s[3..key.to_s.length].gsub(/_/, " ").camelize.humanize}: #{value}"
+          "CF-#{key.to_s[3..key.to_s.length].gsub(/_/, " ").camelize.humanize}"
         elsif key.to_s.match(/^CF-.+/)
-          "#{key.to_s}: #{value}"
+          "#{key.to_s}"
         else
-          "#{key.to_s.camelize}: #{value}"
+          "#{key.to_s.camelize}"
         end
+
+      values = [values] unless values.is_a?(Array)
+      values.each do |value|
+        value = Roart::ContentFormatter.format_string(value.to_s)
+        fields << "#{key_name}: #{value}"
       end
     end
     content = fields.compact.sort.join("\n")

--- a/lib/roart/core/hash.rb
+++ b/lib/roart/core/hash.rb
@@ -5,6 +5,8 @@ class Hash
         value = Roart::ContentFormatter.format_string(value.to_s)
         if key.to_s.match(/^cf_.+/)
           "CF-#{key.to_s[3..key.to_s.length].gsub(/_/, " ").camelize.humanize}: #{value}"
+        elsif key.to_s.match(/^CF-.+/)
+          "#{key.to_s}: #{value}"
         else
           "#{key.to_s.camelize}: #{value}"
         end

--- a/lib/roart/ticket.rb
+++ b/lib/roart/ticket.rb
@@ -293,7 +293,6 @@ module Roart
         page = page.split("\n")
         status = page.delete_at(0)
         if status.include?("200")
-          page.delete_if{|x| !x.include?(":")}
           page
         else
           raise TicketSystemInterfaceError, "Error Getting Ticket: #{status}"

--- a/spec/roart/core/hash_spec.rb
+++ b/spec/roart/core/hash_spec.rb
@@ -13,6 +13,11 @@ describe 'hash extentions' do
     payload.to_content_format.should == "CF-Stuff: field"
   end
 
+  it 'should NOT change custom key when it starts with CF-' do
+    payload = { 'CF-My CustomField wiTout magic' => 'hello' }
+    payload.to_content_format.should == "CF-My CustomField wiTout magic: hello"
+  end
+
   it 'should use our content formatter for strings' do
     payload = {:subject => 'A new ticket', :queue => 'My queue', :text => "A text"}
     Roart::ContentFormatter.should_receive(:format_string).at_least(:once)

--- a/spec/roart/core/hash_spec.rb
+++ b/spec/roart/core/hash_spec.rb
@@ -24,4 +24,9 @@ describe 'hash extentions' do
     payload.to_content_format
   end
 
+  it "should return sorted data with the same key multiple times when value is array" do
+    payload = { 'CF-My Day' => %w(Tue Wed Fri), 'CF-My Time' => %w(morning evening) }
+    payload.to_content_format.should == "CF-My Day: Fri\nCF-My Day: Tue\nCF-My Day: Wed\nCF-My Time: evening\nCF-My Time: morning"
+  end
+
 end

--- a/spec/roart/ticket_page_spec.rb
+++ b/spec/roart/ticket_page_spec.rb
@@ -1,9 +1,9 @@
-require File.join(File.dirname(__FILE__), %w[ .. spec_helper])
+require 'spec_helper'
 
 describe 'ticket page' do
-  
+
   describe 'ticket hash' do
-    
+
     it 'should convert an array to a hash' do
       array = ["id : 10", "subject : asdf"]
       array.extend(Roart::TicketPage)
@@ -12,82 +12,117 @@ describe 'ticket page' do
       hash[:id].should == 10
       hash[:subject].should == 'asdf'
     end
-  
+
   end
 
-	describe 'reading a ticket' do
-		
-		before do
-			@page = File.open(File.join(File.dirname(__FILE__), %w[ .. test_data ticket.txt])).readlines.join
-			@page = @page.split("\n")
+  describe 'reading a ticket' do
+
+    before do
+      @page = File.open(File.join(File.dirname(__FILE__), %w[ .. test_data ticket.txt])).readlines.join
+      @page = @page.split("\n")
       @page.extend(Roart::TicketPage)
-		end
-		
-		it 'should include custom fields' do
-			@page.to_hash[:cf_BTN].should == '1035328269'
-		end
-		
-		it 'should be a hash' do
-			@page.to_hash.class.should == HashWithIndifferentAccess
-		end
-		
-	end
-  
+    end
+
+    subject { @page.to_hash }
+
+    it 'should be a hash' do
+      subject.class.should == HashWithIndifferentAccess
+    end
+
+    it 'should include id' do
+      subject[:id].should == 358171
+    end
+
+    it 'should include regular fields' do
+      subject[:subject].should == 'MyQueue - some_guy - 1035328269 - DSL Modem Reset ESCALATED'
+    end
+
+    it 'should include custom fields with old format' do
+      subject[:cf_BTN].should == '1035328269'
+    end
+
+    it 'should include custom fields with new format' do
+      subject[:cf_NEW_BTN].should == '2035328269'
+    end
+
+    it 'should properly build old formatted custom fields with multiple line value' do
+      subject['cf_Contact_Source'].should == (<<-DATA).strip
+<contact-info>
+      <name>Jane Smith</name>
+      <company>AT&amp;T</company>
+      <phone>(212) 555-4567</phone>
+    </contact-info>
+DATA
+    end
+
+    it 'should properly build new formatted custom fields with multiple line value' do
+      subject['cf_Feed_Source'].should == (<<-DATA).strip
+<item>
+    <title>Example entry</title>
+    <description>Here is some text containing an interesting description.</description>
+    <link>http://www.wikipedia.org/</link>
+    <guid>unique string per item</guid>
+    <pubDate>Mon, 06 Sep 2009 16:45:00 +0000 </pubDate>
+  </item>
+DATA
+    end
+  end
+
   describe 'search array' do
-    
+
     before do
       @array = ["123 : Subject", "234 : Subject"]
       @array.extend(Roart::TicketPage)
       @array = @array.to_search_array
     end
-    
+
     it 'should make an array of search results' do
       @array.size.should == 2
     end
-    
+
     it 'should put search elements into the search array' do
       @array.first[:id].should == 123
       @array.last[:id].should == 234
     end
-    
+
   end
 
-	describe "search list array" do
-	  before do
-			@array = [['id:234', 'subject:SomeTicket', ], ['id:432','subject:Another']]
+  describe "search list array" do
+    before do
+      @array = [['id:234', 'subject:SomeTicket', ], ['id:432','subject:Another']]
       @array.extend(Roart::TicketPage)
       @array = @array.to_search_list_array
-		end
-		
-		it "should return an array of hashes" do
-		  @array.first.class.should == HashWithIndifferentAccess
-		end
-		
-		it "should put the search elements into the array" do
-			@array.first[:id].should == 234
-		end
-	end
-  
+    end
+
+    it "should return an array of hashes" do
+      @array.first.class.should == HashWithIndifferentAccess
+    end
+
+    it "should put the search elements into the array" do
+      @array.first[:id].should == 234
+    end
+  end
+
   describe 'ticket history hash' do
-    
+
     before do
       @page = File.open(File.join(File.dirname(__FILE__), %w[ .. test_data single_history.txt])).readlines.join
       @page = @page.split("\n")
       @page.extend(Roart::TicketPage)
     end
-    
+
     it 'should give back the hash of history' do
       @page.to_history_hash.class.should == HashWithIndifferentAccess
     end
-    
+
     it 'should have some content' do
-      @page.to_history_hash[:content].should_not be_nil
+      @page.to_history_hash[:content].should == "Now you can get big real fast at an affordable price\nhttp://www.lameppe.com/"
     end
-    
+
     it 'should have the create type' do
       @page.to_history_hash[:type].should == 'Create'
     end
-    
+
   end
-  
+
 end

--- a/spec/roart/ticket_spec.rb
+++ b/spec/roart/ticket_spec.rb
@@ -60,9 +60,9 @@ describe "Ticket" do
     end
     
     it 'should give back an array of strings' do
-      connection = mock('connection', :get => "200 OK\n23:SomeTicket\n33:Another")
+      connection = mock('connection', :get => "200 OK\n23:SomeTicket\n33:Another\nMultilineValue")
       Roart::Ticket.should_receive(:connection).and_return(connection)
-      Roart::Ticket.send(:page_array, 'uri').should == ['23:SomeTicket', '33:Another']
+      Roart::Ticket.send(:page_array, 'uri').should == ['23:SomeTicket', '33:Another', 'MultilineValue']
     end
     
   end

--- a/spec/test_data/ticket.txt
+++ b/spec/test_data/ticket.txt
@@ -29,3 +29,18 @@ CF-Contact Name: some_guy
 CF-Contact Phone:
 CF-CMSID:
 CF-IssueCategory: DSL - Modem/Router Config
+
+CF-Contact Source: <contact-info>
+      <name>Jane Smith</name>
+      <company>AT&amp;T</company>
+      <phone>(212) 555-4567</phone>
+    </contact-info>
+
+CF.{NEW BTN}: 2035328269
+CF.{Feed Source}: <item>
+    <title>Example entry</title>
+    <description>Here is some text containing an interesting description.</description>
+    <link>http://www.wikipedia.org/</link>
+    <guid>unique string per item</guid>
+    <pubDate>Mon, 06 Sep 2009 16:45:00 +0000 </pubDate>
+  </item>


### PR DESCRIPTION
Hello. We continue to contribute :)
- No magic for keys that starts with explict custom field definition 'CF-'
- Ability to create CustomField with multiple values.
- Improved ticket response parsing:
  - Supports rt4 custm field response: CF.{key} 
  - Supports CF with multi-line value (for example CF that contains xml data)

Some times we need to set explicit name for CF key e.g "CF-sOme StraNge_Key"
