### PR TITLE
Support for older versions that fold multi value fields into multiple lines

### DIFF
--- a/lib/roart/ticket.rb
+++ b/lib/roart/ticket.rb
@@ -293,7 +293,6 @@ module Roart
         page = page.split("\n")
         status = page.delete_at(0)
         if status.include?("200")
-          page.delete_if{|x| !x.include?(":")}
           page
         else
           raise TicketSystemInterfaceError, "Error Getting Ticket: #{status}"

--- a/lib/roart/ticket_page.rb
+++ b/lib/roart/ticket_page.rb
@@ -6,6 +6,7 @@ module Roart
 
     def to_hash
       hash = HashWithIndifferentAccess.new
+      unfold_fields!
       self.delete_if{|x| !x.include?(":")}
       return false if self.size == 0
       self.each do |ln|
@@ -22,6 +23,11 @@ module Roart
       end
       hash["id"] = hash["id"].split("/").last.to_i
       hash
+    end
+
+    def unfold_fields!
+      unfolded = join("\n").gsub(/\n +/, " ")
+      replace(unfolded.lines)
     end
 
     def to_search_list_array

--- a/spec/roart/ticket_page_spec.rb
+++ b/spec/roart/ticket_page_spec.rb
@@ -32,7 +32,21 @@ describe 'ticket page' do
 		end
 		
 	end
-  
+
+  describe 'reading an old ticket (v3.2.1)' do
+
+    before do
+      @page = File.open(File.join(File.dirname(__FILE__), %w[ .. test_data ticket-v3.2.1.txt])).readlines.join
+      @page = @page.split("\n")
+      @page.extend(Roart::TicketPage)
+    end
+
+    it 'should unfold multiline fields' do
+      @page.to_hash[:requestors].should match('steve@oceanic.com')
+      @page.to_hash[:requestors].should match('scott@oceanic.com')
+    end
+  end
+
   describe 'search array' do
     
     before do

--- a/spec/test_data/ticket-v3.2.1.txt
+++ b/spec/test_data/ticket-v3.2.1.txt
@@ -1,0 +1,26 @@
+RT/3.2.1 200 Ok
+
+id: ticket/815
+Queue: RspecTests
+Owner: chrisdambrosio
+Creator: chrisdambrosio
+Subject: Support very old installations
+Status: open
+Priority: 0
+InitialPriority: 0
+FinalPriority: 0
+
+Requestors: scott@oceanic.com,
+            steve@oceanic.com
+
+Cc:
+AdminCc:
+Created: Mon Aug 11 11:34:24 2014
+Starts: Not set
+Started: Not set
+Due: Not set
+Resolved: Not set
+Told: Not set
+TimeEstimated: 0
+TimeWorked: 0
+TimeLeft: 0


### PR DESCRIPTION
Older versions of Request tracker split fields with multiple values into new lines.

This pull request supports parsing the values which would otherwise be cut off.
