### PR TITLE
connection options: no ssl verify & basic auth

### DIFF
--- a/lib/roart/connection_adapters/mechanize_adapter.rb
+++ b/lib/roart/connection_adapters/mechanize_adapter.rb
@@ -11,11 +11,21 @@ module Roart
       def login(config)
         @conf.merge!(config)
         agent = Mechanize.new
-        page = agent.get(@conf[:server])
-        form = page.form('login')
-        form.user = @conf[:user]
-        form.pass = @conf[:pass]
-        page = agent.submit form
+
+        if config[:ssl_verify] == :none.to_sym
+          agent.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+
+        if config[:auth_method] == :basic.to_sym
+          agent.add_auth(@conf[:server], @conf[:user], @conf[:pass])
+        else
+          page = agent.get(@conf[:server])
+          form = page.form('login')
+          form.user = @conf[:user]
+          form.pass = @conf[:pass]
+          page = agent.submit form
+        end
+
         @agent = agent
       end
 


### PR DESCRIPTION
New connections options for:
- logging in with basic auth
- disabling SSL certificate verification

``` ruby
class Ticket < Roart::Ticket
  connection(
    :server => 'https://rt.example.com', :user => 'chrisdambrosio', :pass => 'rtpassword',
    :auth_method => :basic, # basic auth
    :ssl_verify  => :none   # disable ssl cert verification
  )
end
```
